### PR TITLE
refactor: consolidate four icon View types into one LucideIcon with style parameter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,10 +99,8 @@ import XCTest     // For tests only
 
 ### Key Components
 1. **LucideShape**: Shape protocol implementation for SVG rendering.
-2. **LucideIcon**: SwiftUI View wrapper for standard icons.
-3. **LucideLabIcon**: SwiftUI View wrapper for experimental Lab icons.
-4. **LucideIconFill / LucideLabIconFill**: SwiftUI View wrappers for solid/filled icons.
-5. **LucideGenerator**: Fetches icons from both `lucide` and `lucide-lab` repositories and generates Swift code.
+2. **LucideIcon**: SwiftUI View wrapper for all icons — supports `.stroked` and `.filled` styles via `LucideIconStyle`, and handles both regular and Lab icons through a unified interface.
+3. **LucideGenerator**: Fetches icons from both `lucide` and `lucide-lab` repositories and generates Swift code.
 
 ### SVG Path Commands Supported
 - `M/m`: Move to
@@ -120,12 +118,13 @@ import XCTest     // For tests only
 ```
 Sources/
 ├── LucideSwift/
-│   ├── LucideIcon.swift        # SwiftUI components
-│   ├── Lucide.swift             # Type-safe icon definitions
+│   ├── LucideIcon.swift        # Unified icon View + Label extensions
+│   ├── Lucide.swift             # LucideShape definition
+│   ├── Image+Lucide.swift       # Image extensions for rasterized icons
 │   ├── Lucide+Generated.swift   # Auto-generated icons (DO NOT EDIT)
-│   └── SVGPathParser.swift      # SVG parsing logic
 └── LucideGenerator/
-    └── main.swift               # Code generation tool
+    ├── main.swift               # Code generation tool
+    └── SVGPathParser.swift      # SVG parsing logic
 ```
 
 ## Workflow

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ struct ContentView: View {
 
 ### Lucide Lab (Experimental)
 
-Experimental icons from the [Lucide Lab](https://github.com/lucide-icons/lucide-lab) repository are available in a separate namespace to clearly distinguish them from the stable set.
+Experimental icons from the [Lucide Lab](https://github.com/lucide-icons/lucide-lab) repository are accessed through the `lab:` parameter.
 
 ```swift
 import LucideSwift
@@ -87,11 +87,11 @@ import SwiftUI
 struct ExperimentalView: View {
     var body: some View {
         VStack {
-            // Dedicated Lab View
-            LucideLabIcon(.broom, size: 32, color: .purple)
+            // Lab icon using lab: label
+            LucideIcon(lab: .broom, size: 32, color: .purple)
             
             // Lab icons in standard Label
-            Label("New Idea", lucideLab: .sparkles)
+            Label("New Idea", lucide: LucideLab.sparkles)
             
             // Access underlying shape
             LucideLab.avocado
@@ -104,14 +104,14 @@ struct ExperimentalView: View {
 
 ### Advanced Usage
 
-#### Filled Icons (Experimental)
+#### Filled Icons
 
 > [!WARNING]
-> `LucideIconFill` is **experimental**. Lucide icons are stroke-based, and filling them can result in artifacts on complex or open paths.
+> Filled rendering is **experimental**. Lucide icons are stroke-based, and filling them can result in artifacts on complex or open paths.
 
 ```swift
-// Filled icons
-LucideIconFill(.star, size: 48, color: .yellow)
+// Filled icons using style: parameter
+LucideIcon(.star, style: .filled, size: 48, color: .yellow)
 ```
 
 #### Other Components
@@ -125,6 +125,11 @@ Label("Settings", lucide: .settings)
 Button(action: {}) {
     Label("Save", lucide: .save)
 }
+
+// Create a SwiftUI Image for more customization
+Image(lucide: .house)
+    .resizable()
+    .frame(width: 48, height: 48)
 ```
 
 ### Stroke Width
@@ -153,11 +158,13 @@ LucideIcon(.heart, size: 48, absoluteStrokeWidth: true)  // 2px stroke (same!)
 ### API Reference
 
 **LucideIcon** - SwiftUI View wrapper
-- `init(_ iconName: LucideIconName, size: CGFloat = 24, color: Color? = nil, strokeWidth: CGFloat = 2, absoluteStrokeWidth: Bool = false)` - Type-safe enum
-- `init(name: String, size: CGFloat = 24, color: Color? = nil, strokeWidth: CGFloat = 2, absoluteStrokeWidth: Bool = false)` - String lookup with fallback
-- `init(_ icon: LucideShape, size: CGFloat = 24, color: Color? = nil, strokeWidth: CGFloat = 2, absoluteStrokeWidth: Bool = false)` - From Shape
+- `init(_ iconName: LucideIconName, style: LucideIconStyle = .stroked, size: CGFloat = 24, color: Color? = nil, strokeWidth: CGFloat = 2, absoluteStrokeWidth: Bool = false)` - Type-safe enum
+- `init(lab iconName: LucideLabIconName, style: LucideIconStyle = .stroked, size: CGFloat = 24, color: Color? = nil, strokeWidth: CGFloat = 2, absoluteStrokeWidth: Bool = false)` - Lab (experimental) icon
+- `init(name: String, style: LucideIconStyle = .stroked, size: CGFloat = 24, color: Color? = nil, strokeWidth: CGFloat = 2, absoluteStrokeWidth: Bool = false)` - String lookup with fallback
+- `init(shape: LucideShape, style: LucideIconStyle = .stroked, size: CGFloat = 24, color: Color? = nil, strokeWidth: CGFloat = 2, absoluteStrokeWidth: Bool = false)` - From Shape
 
 **Parameters:**
+- `style`: Rendering style — `.stroked` (default) or `.filled`
 - `size`: Icon size in points (default: 24)
 - `color`: Icon color (default: `nil`, inherits from environment foreground color)
 - `strokeWidth`: Stroke width multiplier (default: 2)

--- a/Sources/LucideSwift/Image+Lucide.swift
+++ b/Sources/LucideSwift/Image+Lucide.swift
@@ -10,7 +10,7 @@ import CoreGraphics
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, visionOS 1.0, *)
 public extension Image {
-    
+
     /// Creates a SwiftUI Image from a LucideShape.
     ///
     /// The resulting image is generated in template rendering mode, meaning it
@@ -24,47 +24,32 @@ public extension Image {
     ///   - shape: The LucideShape to render
     ///   - size: The target point size of the image (default 24x24)
     ///   - strokeWidth: The stroke width to use (default 2)
-    init(lucide shape: LucideShape, size: CGSize = CGSize(width: 24, height: 24), strokeWidth: CGFloat = 2) {
-        let cgImage = Self.renderTemplate(shape: shape, size: size, strokeWidth: strokeWidth, isFilled: false)
+    ///   - style: The rendering style — `.stroked` (default) or `.filled`
+    init(lucide shape: LucideShape, size: CGSize = CGSize(width: 24, height: 24), strokeWidth: CGFloat = 2, style: LucideIconStyle = .stroked) {
+        let cgImage = Self.renderTemplate(shape: shape, size: size, strokeWidth: strokeWidth, style: style)
         self = Image(cgImage, scale: 3.0, label: Text("Lucide Icon")).renderingMode(.template)
     }
-    
-    /// Creates a filled SwiftUI Image from a LucideShape.
-    init(lucideFill shape: LucideShape, size: CGSize = CGSize(width: 24, height: 24), strokeWidth: CGFloat = 2) {
-        let cgImage = Self.renderTemplate(shape: shape, size: size, strokeWidth: strokeWidth, isFilled: true)
-        self = Image(cgImage, scale: 3.0, label: Text("Lucide Filled Icon")).renderingMode(.template)
+
+    /// Creates a SwiftUI Image from a ``LucideIconName``.
+    init(lucide iconName: LucideIconName, size: CGSize = CGSize(width: 24, height: 24), strokeWidth: CGFloat = 2, style: LucideIconStyle = .stroked) {
+        self.init(lucide: LucideShape(path: iconName.path), size: size, strokeWidth: strokeWidth, style: style)
     }
-    
-    /// Creates a SwiftUI Image from a LucideIconName.
-    init(lucide iconName: LucideIconName, size: CGSize = CGSize(width: 24, height: 24), strokeWidth: CGFloat = 2) {
-        self.init(lucide: LucideShape(path: iconName.path), size: size, strokeWidth: strokeWidth)
+
+    /// Creates a SwiftUI Image from a ``LucideLabIconName``.
+    init(lucideLab iconName: LucideLabIconName, size: CGSize = CGSize(width: 24, height: 24), strokeWidth: CGFloat = 2, style: LucideIconStyle = .stroked) {
+        self.init(lucide: LucideShape(path: iconName.path), size: size, strokeWidth: strokeWidth, style: style)
     }
-    
-    /// Creates a filled SwiftUI Image from a LucideIconName.
-    init(lucideFill iconName: LucideIconName, size: CGSize = CGSize(width: 24, height: 24), strokeWidth: CGFloat = 2) {
-        self.init(lucideFill: LucideShape(path: iconName.path), size: size, strokeWidth: strokeWidth)
-    }
-    
-    /// Creates a SwiftUI Image from a LucideLabIconName.
-    init(lucideLab iconName: LucideLabIconName, size: CGSize = CGSize(width: 24, height: 24), strokeWidth: CGFloat = 2) {
-        self.init(lucide: LucideShape(path: iconName.path), size: size, strokeWidth: strokeWidth)
-    }
-    
-    /// Creates a filled SwiftUI Image from a LucideLabIconName.
-    init(lucideLabFill iconName: LucideLabIconName, size: CGSize = CGSize(width: 24, height: 24), strokeWidth: CGFloat = 2) {
-        self.init(lucideFill: LucideShape(path: iconName.path), size: size, strokeWidth: strokeWidth)
-    }
-    
+
     // MARK: - Private Renderer
-    
-    private static func renderTemplate(shape: LucideShape, size: CGSize, strokeWidth: CGFloat, isFilled: Bool) -> CGImage {
+
+    private static func renderTemplate(shape: LucideShape, size: CGSize, strokeWidth: CGFloat, style: LucideIconStyle) -> CGImage {
         let scale: CGFloat = 3.0 // Render at @3x scale for retina sharpness
         let pixelWidth = max(1, Int(size.width * scale))
         let pixelHeight = max(1, Int(size.height * scale))
-        
+
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
-        
+
         guard let context = CGContext(
             data: nil,
             width: pixelWidth,
@@ -76,17 +61,17 @@ public extension Image {
         ) else {
             return createEmptyCGImage()
         }
-        
+
         context.setAllowsAntialiasing(true)
         context.setShouldAntialias(true)
-        
+
         // Flip coordinate system to match SwiftUI (Top-left origin)
         context.translateBy(x: 0, y: CGFloat(pixelHeight))
         context.scaleBy(x: scale, y: -scale)
-        
+
         let rect = CGRect(origin: .zero, size: size)
-        
-        if isFilled {
+
+        if style == .filled {
             // Draw filled portions
             let closedPath = shape.closedPath(in: rect)
             if !closedPath.isEmpty {
@@ -95,7 +80,7 @@ public extension Image {
                 // EO fill rule matches how Lucide shapes are generated
                 context.drawPath(using: .eoFill)
             }
-            
+
             // Draw stroked portions
             let openPath = shape.openPath(in: rect)
             if !openPath.isEmpty {
@@ -118,10 +103,10 @@ public extension Image {
                 context.strokePath()
             }
         }
-        
+
         return context.makeImage() ?? createEmptyCGImage()
     }
-    
+
     private static func createEmptyCGImage() -> CGImage {
         let context = CGContext(
             data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,

--- a/Sources/LucideSwift/Lucide.swift
+++ b/Sources/LucideSwift/Lucide.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///
 /// `LucideShape` is the underlying vector representation of a Lucide icon.
 /// While you can use it directly like any other SwiftUI `Shape`, it is usually
-/// easier to use the ``LucideIcon`` or ``LucideIconFill`` views.
+/// easier to use the ``LucideIcon`` view.
 ///
 /// ### Example
 /// ```swift

--- a/Sources/LucideSwift/LucideIcon.swift
+++ b/Sources/LucideSwift/LucideIcon.swift
@@ -7,21 +7,52 @@
 
 import SwiftUI
 
-/// Error thrown when an invalid icon name is provided
-public enum LucideIconError: Error {
-    case iconNotFound(String)
+/// The rendering style for a Lucide icon.
+public enum LucideIconStyle: Sendable {
+    /// Stroke-only rendering — the standard Lucide look.
+    case stroked
+    /// Filled rendering: closed paths are filled, open paths are stroked.
+    case filled
 }
 
-// MARK: - Regular Icons
+// MARK: - Icon Resolution
+
+private func resolveShape(named name: String, caller: String = "LucideIcon") -> LucideShape {
+    if let iconName = LucideIconName(rawValue: name) {
+        return LucideShape(path: iconName.path)
+    } else if let labIconName = LucideLabIconName(rawValue: name) {
+        return LucideShape(path: labIconName.path)
+    }
+    #if DEBUG
+    print("⚠️ \(caller): Icon '\(name)' not found in regular or lab sets, using fallback")
+    #endif
+    return LucideShape(path: LucideIconName.house.path)
+}
+
+// MARK: - LucideIcon
 
 /// A SwiftUI view that displays a Lucide icon.
 ///
 /// `LucideIcon` is the primary way to display icons in your app. It provides
-/// high-level controls for sizing, coloring, and stroke width.
+/// high-level controls for sizing, coloring, and stroke width, and supports
+/// both regular and experimental (Lab) icons through a unified interface.
 ///
 /// ### Example
 /// ```swift
+/// // Stroked (default)
 /// LucideIcon(.house, size: 32, color: .blue, strokeWidth: 1.5)
+///
+/// // Filled
+/// LucideIcon(.star, style: .filled, color: .yellow)
+///
+/// // Lab icons — explicit lab: label
+/// LucideIcon(lab: .broom, color: .purple)
+///
+/// // From a Shape
+/// LucideIcon(Lucide.settings)
+///
+/// // From a string
+/// LucideIcon(name: "house")
 /// ```
 public struct LucideIcon: View {
     let iconShape: LucideShape
@@ -29,233 +60,100 @@ public struct LucideIcon: View {
     var color: Color?
     var strokeWidth: CGFloat
     var absoluteStrokeWidth: Bool
-    
+    var style: LucideIconStyle
+
     /// Initialize with a ``LucideShape``.
     /// - Parameters:
-    ///   - icon: The icon shape to display.
+    ///   - shape: The icon shape to display.
+    ///   - style: The rendering style — `.stroked` (default) or `.filled`.
     ///   - size: The base size of the icon in points (default 24).
     ///   - color: The color of the icon (default nil, inherits from environment).
     ///   - strokeWidth: The stroke width in points (default 2).
     ///   - absoluteStrokeWidth: If true, stroke width remains constant regardless of size.
     public init(
-        _ icon: LucideShape,
+        shape: LucideShape,
+        style: LucideIconStyle = .stroked,
         size: CGFloat = 24,
         color: Color? = nil,
         strokeWidth: CGFloat = 2,
         absoluteStrokeWidth: Bool = false
     ) {
-        self.iconShape = icon
+        self.iconShape = shape
+        self.style = style
         self._size = ScaledMetric(wrappedValue: size)
         self.color = color
         self.strokeWidth = strokeWidth
         self.absoluteStrokeWidth = absoluteStrokeWidth
     }
-    
+
     /// Initialize with a ``LucideIconName`` enum case.
     public init(
         _ iconName: LucideIconName,
+        style: LucideIconStyle = .stroked,
         size: CGFloat = 24,
         color: Color? = nil,
         strokeWidth: CGFloat = 2,
         absoluteStrokeWidth: Bool = false
     ) {
-        self.iconShape = LucideShape(path: iconName.path)
-        self._size = ScaledMetric(wrappedValue: size)
-        self.color = color
-        self.strokeWidth = strokeWidth
-        self.absoluteStrokeWidth = absoluteStrokeWidth
+        self.init(shape: LucideShape(path: iconName.path), style: style, size: size, color: color, strokeWidth: strokeWidth, absoluteStrokeWidth: absoluteStrokeWidth)
     }
-    
-    /// Initialize with a string icon name (type-safe lookup with fallback).
+
+    /// Initialize with a ``LucideLabIconName`` enum case.
+    /// Use this to explicitly render a lab (experimental) icon.
+    public init(
+        lab iconName: LucideLabIconName,
+        style: LucideIconStyle = .stroked,
+        size: CGFloat = 24,
+        color: Color? = nil,
+        strokeWidth: CGFloat = 2,
+        absoluteStrokeWidth: Bool = false
+    ) {
+        self.init(shape: LucideShape(path: iconName.path), style: style, size: size, color: color, strokeWidth: strokeWidth, absoluteStrokeWidth: absoluteStrokeWidth)
+    }
+
+    /// Initialize with a string icon name (looks up across regular and lab sets).
     /// - Parameters:
-    ///   - name: The icon name (e.g., "house", "settings", "heart").
+    ///   - name: The icon name (e.g., "house", "settings", "broom").
+    ///   - style: The rendering style — `.stroked` (default) or `.filled`.
     ///   - size: The icon size (default: 24).
     ///   - color: The icon color (default: nil, inherits from environment).
     ///   - strokeWidth: The stroke width (default: 2).
     ///   - absoluteStrokeWidth: When true, stroke width stays constant regardless of icon size.
     public init(
         name: String,
+        style: LucideIconStyle = .stroked,
         size: CGFloat = 24,
         color: Color? = nil,
         strokeWidth: CGFloat = 2,
         absoluteStrokeWidth: Bool = false
     ) {
-        if let iconName = LucideIconName(rawValue: name) {
-            self.iconShape = LucideShape(path: iconName.path)
-        } else if let labIconName = LucideLabIconName(rawValue: name) {
-            self.iconShape = LucideShape(path: labIconName.path)
-        } else {
-            // Fallback to house if not found
-            self.iconShape = LucideShape(path: LucideIconName.house.path)
-            #if DEBUG
-            print("⚠️ LucideIcon: Icon '\(name)' not found in regular or lab sets, using fallback")
-            #endif
-        }
-        self._size = ScaledMetric(wrappedValue: size)
-        self.color = color
-        self.strokeWidth = strokeWidth
-        self.absoluteStrokeWidth = absoluteStrokeWidth
+        self.init(shape: resolveShape(named: name), style: style, size: size, color: color, strokeWidth: strokeWidth, absoluteStrokeWidth: absoluteStrokeWidth)
     }
-    
-    public var body: some View {
-        let actualStrokeWidth: CGFloat = absoluteStrokeWidth ? strokeWidth : strokeWidth * (size / 24)
-        let style = StrokeStyle(lineWidth: actualStrokeWidth, lineCap: .round, lineJoin: .round)
-        
-        return Group {
-            if let color = color {
-                iconShape.stroke(color, style: style)
-            } else {
-                iconShape.stroke(style: style)
-            }
-        }
-        .frame(width: size, height: size)
-    }
-}
 
-/// A SwiftUI view that displays a filled Lucide icon.
-///
-/// `LucideIconFill` renders closed areas of the icon with a solid fill,
-/// while keeping decorative lines as strokes.
-///
-/// ### Example
-/// ```swift
-/// LucideIconFill(.star, color: .yellow)
-/// ```
-public struct LucideIconFill: View {
-    let iconShape: LucideShape
-    @ScaledMetric var size: CGFloat
-    var color: Color?
-    var strokeWidth: CGFloat
-    var absoluteStrokeWidth: Bool
-    
-    /// Initialize with a ``LucideShape``.
-    public init(
-        _ icon: LucideShape,
-        size: CGFloat = 24,
-        color: Color? = nil,
-        strokeWidth: CGFloat = 2,
-        absoluteStrokeWidth: Bool = false
-    ) {
-        self.iconShape = icon
-        self._size = ScaledMetric(wrappedValue: size)
-        self.color = color
-        self.strokeWidth = strokeWidth
-        self.absoluteStrokeWidth = absoluteStrokeWidth
-    }
-    
-    /// Initialize with a ``LucideIconName`` enum case.
-    public init(
-        _ iconName: LucideIconName,
-        size: CGFloat = 24,
-        color: Color? = nil,
-        strokeWidth: CGFloat = 2,
-        absoluteStrokeWidth: Bool = false
-    ) {
-        self.iconShape = LucideShape(path: iconName.path)
-        self._size = ScaledMetric(wrappedValue: size)
-        self.color = color
-        self.strokeWidth = strokeWidth
-        self.absoluteStrokeWidth = absoluteStrokeWidth
-    }
-    
-    /// Initialize with a string icon name (type-safe lookup with fallback).
-    public init(
-        name: String,
-        size: CGFloat = 24,
-        color: Color? = nil,
-        strokeWidth: CGFloat = 2,
-        absoluteStrokeWidth: Bool = false
-    ) {
-        if let iconName = LucideIconName(rawValue: name) {
-            self.iconShape = LucideShape(path: iconName.path)
-        } else if let labIconName = LucideLabIconName(rawValue: name) {
-            self.iconShape = LucideShape(path: labIconName.path)
-        } else {
-            self.iconShape = LucideShape(path: LucideIconName.house.path)
-            #if DEBUG
-            print("⚠️ LucideIconFill: Icon '\(name)' not found in regular or lab sets, using fallback")
-            #endif
-        }
-        self._size = ScaledMetric(wrappedValue: size)
-        self.color = color
-        self.strokeWidth = strokeWidth
-        self.absoluteStrokeWidth = absoluteStrokeWidth
-    }
-    
     public var body: some View {
         let actualStrokeWidth: CGFloat = absoluteStrokeWidth ? strokeWidth : strokeWidth * (size / 24)
         let strokeStyle = StrokeStyle(lineWidth: actualStrokeWidth, lineCap: .round, lineJoin: .round)
         let fillStyle = FillStyle(eoFill: true)
         let rect = CGRect(x: 0, y: 0, width: size, height: size)
-        
+
+        // For filled style, stroke only the open subpaths; for stroked style, stroke the full path.
+        let strokePath = style == .filled ? iconShape.openPath(in: rect) : iconShape.path(in: rect)
+
         return ZStack {
+            if style == .filled {
+                if let color = color {
+                    iconShape.closedPath(in: rect).fill(color, style: fillStyle)
+                } else {
+                    iconShape.closedPath(in: rect).fill(style: fillStyle)
+                }
+            }
             if let color = color {
-                iconShape.closedPath(in: rect).fill(color, style: fillStyle)
-                iconShape.openPath(in: rect).stroke(color, style: strokeStyle)
+                strokePath.stroke(color, style: strokeStyle)
             } else {
-                iconShape.closedPath(in: rect).fill(style: fillStyle)
-                iconShape.openPath(in: rect).stroke(style: strokeStyle)
+                strokePath.stroke(style: strokeStyle)
             }
         }
         .frame(width: size, height: size)
-    }
-}
-
-// MARK: - Lab Icons
-
-/// A view that displays an experimental Lucide Lab icon
-public struct LucideLabIcon: View {
-    let iconShape: LucideShape
-    var size: CGFloat
-    var color: Color?
-    var strokeWidth: CGFloat
-    var absoluteStrokeWidth: Bool
-    
-    /// Initialize with a LucideLabIconName enum case
-    public init(
-        _ iconName: LucideLabIconName,
-        size: CGFloat = 24,
-        color: Color? = nil,
-        strokeWidth: CGFloat = 2,
-        absoluteStrokeWidth: Bool = false
-    ) {
-        self.iconShape = LucideShape(path: iconName.path)
-        self.size = size
-        self.color = color
-        self.strokeWidth = strokeWidth
-        self.absoluteStrokeWidth = absoluteStrokeWidth
-    }
-    
-    public var body: some View {
-        LucideIcon(iconShape, size: size, color: color, strokeWidth: strokeWidth, absoluteStrokeWidth: absoluteStrokeWidth)
-    }
-}
-
-/// A view that displays a filled experimental Lucide Lab icon
-public struct LucideLabIconFill: View {
-    let iconShape: LucideShape
-    var size: CGFloat
-    var color: Color?
-    var strokeWidth: CGFloat
-    var absoluteStrokeWidth: Bool
-    
-    /// Initialize with a LucideLabIconName enum case
-    public init(
-        _ iconName: LucideLabIconName,
-        size: CGFloat = 24,
-        color: Color? = nil,
-        strokeWidth: CGFloat = 2,
-        absoluteStrokeWidth: Bool = false
-    ) {
-        self.iconShape = LucideShape(path: iconName.path)
-        self.size = size
-        self.color = color
-        self.strokeWidth = strokeWidth
-        self.absoluteStrokeWidth = absoluteStrokeWidth
-    }
-    
-    public var body: some View {
-        LucideIconFill(iconShape, size: size, color: color, strokeWidth: strokeWidth, absoluteStrokeWidth: absoluteStrokeWidth)
     }
 }
 
@@ -269,7 +167,7 @@ extension LucideIconName {
         guard let iconName = LucideIconName(rawValue: name) else { return nil }
         return LucideShape(path: iconName.path)
     }
-    
+
     /// A list of all available icon names in the regular set.
     public static var allNames: [String] {
         LucideIconName.allCases.map { $0.rawValue }
@@ -282,7 +180,7 @@ extension LucideLabIconName {
         guard let iconName = LucideLabIconName(rawValue: name) else { return nil }
         return LucideShape(path: iconName.path)
     }
-    
+
     /// A list of all available icon names in the experimental lab set.
     public static var allNames: [String] {
         LucideLabIconName.allCases.map { $0.rawValue }
@@ -293,37 +191,23 @@ extension LucideLabIconName {
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, visionOS 1.0, *)
 public extension Label where Title == Text, Icon == LucideIcon {
-    /// Creates a label with a Lucide icon.
-    /// - Parameters:
-    ///   - titleKey: A key for the localized title.
-    ///   - icon: The Lucide icon to display.
-    ///   - size: The size of the icon (default 24).
-    init(_ titleKey: LocalizedStringKey, lucide icon: LucideIconName, size: CGFloat = 24) {
-        self.init(title: { Text(titleKey) }, icon: { LucideIcon(icon, size: size) })
+    /// Creates a label with a Lucide icon from a shape.
+    init(_ titleKey: LocalizedStringKey, lucide shape: LucideShape, style: LucideIconStyle = .stroked, size: CGFloat = 24) {
+        self.init(title: { Text(titleKey) }, icon: { LucideIcon(shape: shape, style: style, size: size) })
     }
-    
-    /// Creates a label with an experimental Lucide Lab icon.
-    init(_ titleKey: LocalizedStringKey, lucideLab icon: LucideLabIconName, size: CGFloat = 24) {
-        self.init(title: { Text(titleKey) }, icon: { LucideIcon(LucideShape(path: icon.path), size: size) })
+
+    /// Creates a label with a Lucide icon from a shape using a title string.
+    init<S: StringProtocol>(_ title: S, lucide shape: LucideShape, style: LucideIconStyle = .stroked, size: CGFloat = 24) {
+        self.init(title: { Text(title) }, icon: { LucideIcon(shape: shape, style: style, size: size) })
     }
-    
-    /// Creates a label with a Lucide icon from its string name.
-    init(_ titleKey: LocalizedStringKey, lucideName iconName: String, size: CGFloat = 24) {
-        self.init(title: { Text(titleKey) }, icon: { LucideIcon(name: iconName, size: size) })
+
+    /// Creates a label with a Lucide icon from a ``LucideIconName`` case (shorthand convenience).
+    init(_ titleKey: LocalizedStringKey, lucide iconName: LucideIconName, style: LucideIconStyle = .stroked, size: CGFloat = 24) {
+        self.init(title: { Text(titleKey) }, icon: { LucideIcon(iconName, style: style, size: size) })
     }
-    
-    /// Creates a label with a Lucide icon using a title string.
-    init<S: StringProtocol>(_ title: S, lucide icon: LucideIconName, size: CGFloat = 24) {
-        self.init(title: { Text(title) }, icon: { LucideIcon(icon, size: size) })
-    }
-    
-    /// Creates a label with an experimental Lucide Lab icon using a title string.
-    init<S: StringProtocol>(_ title: S, lucideLab icon: LucideLabIconName, size: CGFloat = 24) {
-        self.init(title: { Text(title) }, icon: { LucideIcon(LucideShape(path: icon.path), size: size) })
-    }
-    
-    /// Creates a label with a Lucide icon from its string name using a title string.
-    init<S: StringProtocol>(_ title: S, lucideName iconName: String, size: CGFloat = 24) {
-        self.init(title: { Text(title) }, icon: { LucideIcon(name: iconName, size: size) })
+
+    /// Creates a label with a Lucide icon from a ``LucideIconName`` case using a title string.
+    init<S: StringProtocol>(_ title: S, lucide iconName: LucideIconName, style: LucideIconStyle = .stroked, size: CGFloat = 24) {
+        self.init(title: { Text(title) }, icon: { LucideIcon(iconName, style: style, size: size) })
     }
 }

--- a/Sources/LucideSwift/LucideSwift.docc/LucideSwift.md
+++ b/Sources/LucideSwift/LucideSwift.docc/LucideSwift.md
@@ -12,7 +12,7 @@ LucideSwift is a collection of over 1,000 high-quality, open-source icons for Sw
 - **Pure SwiftUI:** Icons are implemented as native `Shape` and `View` components.
 - **Zero Runtime Dependencies:** Icons are pre-generated into Swift code for maximum performance.
 - **Customizable:** Easily adjust size, color, stroke width, and scaling behavior.
-- **Filled Icons:** Supports both stroked and filled variations of almost every icon.
+- **Filled Icons:** Switch between stroked and filled rendering with a `style:` parameter.
 
 ## Getting Started
 
@@ -34,7 +34,6 @@ struct ContentView: View {
 ### Core Components
 
 - ``LucideIcon``
-- ``LucideIconFill``
 - ``LucideShape``
 
 ### Icon Sets

--- a/Sources/PreviewGenerator/LucideGallery.swift
+++ b/Sources/PreviewGenerator/LucideGallery.swift
@@ -81,7 +81,7 @@ public struct LucideGallery: View {
                             Text("String").font(.caption2)
                         }
                         VStack {
-                            LucideIcon(Lucide.star, size: 32, color: .yellow)
+                            LucideIcon(shape: Lucide.star, size: 32, color: .yellow)
                             Text("Shape").font(.caption2)
                         }
                     }
@@ -91,10 +91,10 @@ public struct LucideGallery: View {
                 VStack(spacing: 12) {
                     Text("Filled Icons").font(.headline)
                     HStack(spacing: 25) {
-                        LucideIconFill(.star, size: 32, color: .yellow)
-                        LucideIconFill(.heart, size: 32, color: .red)
-                        LucideIconFill(.bell, size: 32, color: .blue)
-                        LucideIconFill(name: "circleCheck", size: 32, color: .green)
+                        LucideIcon(.star, style: .filled, size: 32, color: .yellow)
+                        LucideIcon(.heart, style: .filled, size: 32, color: .red)
+                        LucideIcon(.bell, style: .filled, size: 32, color: .blue)
+                        LucideIcon(name: "circleCheck", style: .filled, size: 32, color: .green)
                     }
                 }
 
@@ -103,7 +103,7 @@ public struct LucideGallery: View {
                     Text("Label Integration").font(.headline)
                     VStack(alignment: .leading, spacing: 10) {
                         Label("Default Label", lucide: .info)
-                        Label("Lab Label", lucideLab: .broom)
+                        Label("Lab Label", lucide: LucideLab.broom)
                             .foregroundColor(.purple)
 
                         Button(action: {}) {
@@ -122,19 +122,19 @@ public struct LucideGallery: View {
                     Text("Experimental icons from the lab repository").font(.caption).foregroundColor(.secondary)
                     HStack(spacing: 20) {
                         VStack {
-                            LucideLabIcon(.broom, size: 32, color: .purple)
+                            LucideIcon(lab: .broom, size: 32, color: .purple)
                             Text("broom").font(.caption2)
                         }
                         VStack {
-                            LucideLabIcon(.avocado, size: 32, color: .green)
+                            LucideIcon(lab: .avocado, size: 32, color: .green)
                             Text("avocado").font(.caption2)
                         }
                         VStack {
-                            LucideLabIcon(.cactus, size: 32, color: .green)
+                            LucideIcon(lab: .cactus, size: 32, color: .green)
                             Text("cactus").font(.caption2)
                         }
                         VStack {
-                            LucideLabIcon(.burger, size: 32, color: .orange)
+                            LucideIcon(lab: .burger, size: 32, color: .orange)
                             Text("burger").font(.caption2)
                         }
                     }
@@ -148,7 +148,7 @@ public struct LucideGallery: View {
                         Image(lucide: .house, size: CGSize(width: 32, height: 32))
                             .foregroundColor(.blue)
 
-                        Image(lucideFill: .heart, size: CGSize(width: 32, height: 32))
+                        Image(lucide: .heart, size: CGSize(width: 32, height: 32), style: .filled)
                             .foregroundColor(.red)
 
                         Image(lucide: .settings, size: CGSize(width: 32, height: 32))

--- a/Tests/LucideSwiftTests/LucideSwiftTests.swift
+++ b/Tests/LucideSwiftTests/LucideSwiftTests.swift
@@ -20,7 +20,7 @@ final class LucideSwiftTests: XCTestCase {
     }
 
     func testIconView() {
-        let icon = LucideIcon(Lucide.house, size: 24, color: .blue)
+        let icon = LucideIcon(shape: Lucide.house, size: 24, color: .blue)
         // Just verify it compiles and creates a view
         XCTAssertNotNil(icon)
     }
@@ -34,16 +34,16 @@ final class LucideSwiftTests: XCTestCase {
         XCTAssertNotNil(avocadoIcon)
 
         // Test lab icon view
-        let iconView = LucideLabIcon(.broom, size: 32, color: .purple)
+        let iconView = LucideIcon(lab: .broom, size: 32, color: .purple)
         XCTAssertNotNil(iconView)
     }
 
     func testImageExtension() {
         // Verify Image initializers compile and return non-nil Image views
         let image1 = Image(lucide: .house)
-        let image2 = Image(lucideFill: .heart)
+        let image2 = Image(lucide: .heart, style: .filled)
         let image3 = Image(lucideLab: .broom)
-        let image4 = Image(lucideLabFill: .avocado)
+        let image4 = Image(lucideLab: .avocado, style: .filled)
 
         XCTAssertNotNil(image1)
         XCTAssertNotNil(image2)
@@ -93,7 +93,7 @@ final class LucideSwiftTests: XCTestCase {
         XCTAssertNotNil(unknown)
 
         // Filled version
-        let filledHouse = LucideIconFill(name: "house")
+        let filledHouse = LucideIcon(name: "house", style: .filled)
         XCTAssertNotNil(filledHouse)
     }
 }


### PR DESCRIPTION
## Summary

Replace `LucideIcon`, `LucideIconFill`, `LucideLabIcon`, and `LucideLabIconFill` with a single unified `LucideIcon` View that accepts a `LucideIconStyle` parameter (`.stroked` / `.filled`).

## Motivation

The four View types shared nearly identical interfaces (same stored properties, same initializer patterns), duplicated string→icon resolution logic, and had inconsistent behaviors (Lab variants lacked `@ScaledMetric` for Dynamic Type). The Image extension mirrored this with 6 initializers.

## Changes

### Public API

```swift
// Before
LucideIcon(.house)                      // stroked
LucideIconFill(.star, color: .yellow)   // filled
LucideLabIcon(.broom, color: .purple)   // lab stroked

// After
LucideIcon(.house)                                     // stroked (default)
LucideIcon(.star, style: .filled, color: .yellow)      // filled
LucideIcon(lab: .broom, color: .purple)                 // lab — explicit lab: label
```

### What changed

- **Added** `LucideIconStyle` enum (`.stroked`, `.filled`)
- **Rewrote** `LucideIcon` with unified ZStack body and 4 initializers (shape, enum, lab enum, string)
- **Extracted** `resolveShape(named:)` — single string→shape resolution with fallback, now shared
- **Lab icons** gain `@ScaledMetric` Dynamic Type support (was missing in `LucideLabIcon`)
- **Image extension**: 6 → 3 initializers, `style:` parameter replaces separate fill variants
- **Label extension**: 6 → 4 initializers
- **Removed**: `LucideIconFill`, `LucideLabIcon`, `LucideLabIconFill`, `LucideIconError`

**Net: −126 lines**, same rendered output. 8 files changed. All 9 tests pass.

### BREAKING

`LucideIconFill`, `LucideLabIcon`, and `LucideLabIconFill` are removed. Migrate:
- `LucideIconFill(.star)` → `LucideIcon(.star, style: .filled)`
- `LucideLabIcon(.broom)` → `LucideIcon(lab: .broom)`
- `LucideLabIconFill(.x)` → `LucideIcon(lab: .x, style: .filled)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)