### PR TITLE
fix: benchmark compile errors — imports, @main, types

### DIFF
--- a/Benchmarks/Sources/LucideBenchmark/BenchmarkMain.swift
+++ b/Benchmarks/Sources/LucideBenchmark/BenchmarkMain.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 
 // MARK: - Lucide Benchmark
 

--- a/Benchmarks/Sources/LucideBenchmark/LookupSpeedBenchmark.swift
+++ b/Benchmarks/Sources/LucideBenchmark/LookupSpeedBenchmark.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import LucideSwift
 import LucideIcons
 

--- a/Benchmarks/Sources/LucideBenchmark/MemoryBenchmark.swift
+++ b/Benchmarks/Sources/LucideBenchmark/MemoryBenchmark.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import LucideSwift
 import LucideIcons
 

--- a/Benchmarks/Sources/LucideBenchmark/NameConversion.swift
+++ b/Benchmarks/Sources/LucideBenchmark/NameConversion.swift
@@ -93,7 +93,7 @@ enum NameConversion {
                 // The "01" part: the '0' already got a dash from letter→digit, '1' follows '0' — no new dash needed
             }
 
-            result.append(isUpper ? Character(scalar).lowercased() : Character(scalar))
+            result.append(isUpper ? Character(scalar).lowercased() : String(scalar))
         }
 
         return result

--- a/Benchmarks/Sources/LucideBenchmark/RenderBenchmark.swift
+++ b/Benchmarks/Sources/LucideBenchmark/RenderBenchmark.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import SwiftUI
 import CoreGraphics
 import LucideSwift
@@ -98,7 +99,7 @@ enum RenderBenchmark {
     private static func renderLucideIconsImage(named name: String, size: CGSize) -> CGImage? {
         guard let nsImage = NSImage.image(lucideId: name) else { return nil }
         guard let tiffData = nsImage.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData) else {
+              let _ = NSBitmapImageRep(data: tiffData) else {
             return nil
         }
 


### PR DESCRIPTION
Fixes found when running benchmark locally:
- Rename main.swift → BenchmarkMain.swift (@main conflicts with top-level code)
- Add import AppKit for NSImage in lookup, memory, render benchmarks
- Fix Character/String type mismatch in NameConversion
- Remove unused bitmap variable in RenderBenchmark