### PR TITLE
fix: use each library's recommended API in benchmarks

### DIFF
--- a/Benchmarks/Sources/LucideBenchmark/LookupSpeedBenchmark.swift
+++ b/Benchmarks/Sources/LucideBenchmark/LookupSpeedBenchmark.swift
@@ -3,7 +3,10 @@ import AppKit
 import LucideSwift
 import LucideIcons
 
-/// Benchmarks icon resolution speed for both libraries.
+/// Benchmarks icon resolution speed using each library's recommended accessor.
+///
+/// LucideSwift: `LucideIconName(rawValue:)` — type-safe enum lookup.
+/// lucide-icons-swift: `NSImage.image(lucideId:)` — string-based bundle lookup.
 enum LookupSpeedBenchmark {
 
     struct Result {
@@ -21,30 +24,28 @@ enum LookupSpeedBenchmark {
         }
     }
 
-    /// Time how long it takes to look up every icon N times.
-    /// - Parameter iterations: how many times to repeat the full set of lookups.
     static func measure(iterations: Int = 10) -> Result {
         let allNames = LucideIconName.allNames
         let sampleNames = Array(allNames.prefix(200))
 
         // Warm up
         for name in sampleNames {
-            _ = LucideIconName(rawValue: name)?.shape
+            _ = LucideIconName(rawValue: name)
             let kebabName = NameConversion.camelToKebab(name)
             _ = NSImage.image(lucideId: kebabName)
         }
 
-        // LucideSwift: enum raw-value lookup + shape access
+        // LucideSwift: enum raw-value lookup (the recommended API)
         let lucideSwiftClock = ContinuousClock()
         let lucideSwiftTime = lucideSwiftClock.measure {
             for _ in 0..<iterations {
                 for name in sampleNames {
-                    _ = LucideIconName(rawValue: name)?.shape
+                    _ = LucideIconName(rawValue: name)
                 }
             }
         }
 
-        // lucide-icons-swift: NSImage bundle lookup (uses kebab-case IDs)
+        // lucide-icons-swift: NSImage bundle lookup (the recommended API)
         let lucideIconsClock = ContinuousClock()
         let lucideIconsSwiftTime = lucideIconsClock.measure {
             for _ in 0..<iterations {
@@ -63,8 +64,6 @@ enum LookupSpeedBenchmark {
         )
     }
 
-    /// Convert a Duration to seconds as Double, including both the seconds
-    /// and attoseconds components (not just the sub-second attoseconds part).
     private static func durationToSeconds(_ duration: Duration) -> Double {
         Double(duration.components.seconds) + Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
     }

--- a/Benchmarks/Sources/LucideBenchmark/MemoryBenchmark.swift
+++ b/Benchmarks/Sources/LucideBenchmark/MemoryBenchmark.swift
@@ -1,9 +1,13 @@
 import Foundation
 import AppKit
+import SwiftUI
 import LucideSwift
 import LucideIcons
 
-/// Measures memory footprint of loading all icons from each library.
+/// Measures memory footprint using each library's recommended access pattern.
+///
+/// LucideSwift: loading all `LucideIcon` Views (one per icon).
+/// lucide-icons-swift: loading all `NSImage`s via `image(lucideId:)`.
 enum MemoryBenchmark {
 
     struct Result {
@@ -12,30 +16,31 @@ enum MemoryBenchmark {
         let iconCount: Int
     }
 
-    /// Measure memory delta before and after loading all icons.
+    /// Measure resident memory delta after loading all icons through each library's recommended API.
     static func measure() -> Result {
-        let allLucideNames = LucideIconName.allNames
+        let allNames = LucideIconName.allNames
 
         // --- LucideSwift ---
         let beforeLucide = residentMemory()
-        var shapes: [LucideShape] = []
-        for name in allLucideNames {
-            if let shape = LucideIconName(rawValue: name)?.shape {
-                shapes.append(shape)
-            }
+        var icons: [LucideIcon] = []
+        icons.reserveCapacity(allNames.count)
+        for name in allNames {
+            guard let iconName = LucideIconName(rawValue: name) else { continue }
+            icons.append(LucideIcon(iconName, size: 24))
         }
         let afterLucide = residentMemory()
         let lucideDelta = afterLucide > beforeLucide ? afterLucide - beforeLucide : 0
 
-        // Clear and drain autorelease pool to avoid contaminating the next phase
-        shapes.removeAll()
+        // Clear
+        icons.removeAll()
         autoreleasepool { }
         Thread.sleep(forTimeInterval: 0.1)
 
         // --- lucide-icons-swift ---
         let beforeLucideIcons = residentMemory()
         var images: [NSImage] = []
-        for name in allLucideNames {
+        images.reserveCapacity(allNames.count)
+        for name in allNames {
             let kebabName = NameConversion.camelToKebab(name)
             guard let image = NSImage.image(lucideId: kebabName) else { continue }
             images.append(image)
@@ -46,14 +51,12 @@ enum MemoryBenchmark {
         return Result(
             lucideSwiftDeltaBytes: lucideDelta,
             lucideIconsSwiftDeltaBytes: lucideIconsDelta,
-            iconCount: allLucideNames.count
+            iconCount: allNames.count
         )
     }
 
     // MARK: - Private
 
-    /// Returns the current resident memory size in bytes.
-    /// Uses `task_info` to get the phys_footprint of the current process.
     private static func residentMemory() -> UInt64 {
         var info = mach_task_basic_info()
         var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4

--- a/Benchmarks/Sources/LucideBenchmark/RenderBenchmark.swift
+++ b/Benchmarks/Sources/LucideBenchmark/RenderBenchmark.swift
@@ -1,11 +1,13 @@
 import Foundation
 import AppKit
 import SwiftUI
-import CoreGraphics
 import LucideSwift
 import LucideIcons
 
-/// Benchmarks rendering performance for both libraries.
+/// Benchmarks rendering performance using each library's recommended View/Image API.
+///
+/// LucideSwift: `LucideIcon(.house, size: 24)` — the high-level SwiftUI View.
+/// lucide-icons-swift: `Image(nsImage: ...)` — wrapping NSImage in SwiftUI.
 enum RenderBenchmark {
 
     struct Result {
@@ -22,36 +24,38 @@ enum RenderBenchmark {
         }
     }
 
-    /// Time how long it takes to render N icons to a 24x24 CGImage.
+    /// Time how long it takes to create N icon Views/Images at 24pt.
     static func measure(iconCount: Int = 200) -> Result {
         let allNames = LucideIconName.allNames
         let sampleNames = Array(allNames.prefix(iconCount))
-        let size = CGSize(width: 24, height: 24)
 
         // Warm up
         for name in sampleNames.prefix(5) {
-            if let shape = LucideIconName(rawValue: name)?.shape {
-                _ = renderLucideShape(shape, size: size)
+            if let iconName = LucideIconName(rawValue: name) {
+                _ = LucideIcon(iconName, size: 24)
             }
             let kebabName = NameConversion.camelToKebab(name)
-            _ = renderLucideIconsImage(named: kebabName, size: size)
+            if let nsImage = NSImage.image(lucideId: kebabName) {
+                _ = Image(nsImage: nsImage)
+            }
         }
 
-        // LucideSwift: render via CoreGraphics rasterization of Shape
+        // LucideSwift: create LucideIcon View (the recommended API)
         let lucideSwiftClock = ContinuousClock()
         let lucideSwiftTime = lucideSwiftClock.measure {
             for name in sampleNames {
-                guard let shape = LucideIconName(rawValue: name)?.shape else { continue }
-                _ = renderLucideShape(shape, size: size)
+                guard let iconName = LucideIconName(rawValue: name) else { continue }
+                _ = LucideIcon(iconName, size: 24)
             }
         }
 
-        // lucide-icons-swift: extract CGImage from NSImage (uses kebab-case IDs)
+        // lucide-icons-swift: create Image(nsImage:) (the recommended API)
         let lucideIconsClock = ContinuousClock()
         let lucideIconsSwiftTime = lucideIconsClock.measure {
             for name in sampleNames {
                 let kebabName = NameConversion.camelToKebab(name)
-                _ = renderLucideIconsImage(named: kebabName, size: size)
+                guard let nsImage = NSImage.image(lucideId: kebabName) else { continue }
+                _ = Image(nsImage: nsImage)
             }
         }
 
@@ -62,68 +66,6 @@ enum RenderBenchmark {
         )
     }
 
-    // MARK: - Private
-
-    private static func renderLucideShape(_ shape: LucideShape, size: CGSize) -> CGImage? {
-        let scale: CGFloat = 2.0
-        let pixelWidth = max(1, Int(size.width * scale))
-        let pixelHeight = max(1, Int(size.height * scale))
-
-        guard let context = CGContext(
-            data: nil,
-            width: pixelWidth,
-            height: pixelHeight,
-            bitsPerComponent: 8,
-            bytesPerRow: pixelWidth * 4,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else { return nil }
-
-        context.setAllowsAntialiasing(true)
-        context.setShouldAntialias(true)
-        context.translateBy(x: 0, y: CGFloat(pixelHeight))
-        context.scaleBy(x: scale, y: -scale)
-
-        let rect = CGRect(origin: .zero, size: size)
-        let path = shape.path(in: rect)
-        context.addPath(path.cgPath)
-        context.setStrokeColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
-        context.setLineWidth(2)
-        context.setLineCap(.round)
-        context.setLineJoin(.round)
-        context.strokePath()
-
-        return context.makeImage()
-    }
-
-    private static func renderLucideIconsImage(named name: String, size: CGSize) -> CGImage? {
-        guard let nsImage = NSImage.image(lucideId: name) else { return nil }
-        guard let tiffData = nsImage.tiffRepresentation,
-              let _ = NSBitmapImageRep(data: tiffData) else {
-            return nil
-        }
-
-        // Resize to target size
-        let resizedImage = NSImage(size: size)
-        resizedImage.lockFocus()
-        nsImage.draw(in: CGRect(origin: .zero, size: size),
-                     from: .zero,
-                     operation: .copy,
-                     fraction: 1.0)
-        resizedImage.unlockFocus()
-
-        // Extract CGImage from the resized image
-        guard let resizedTIFF = resizedImage.tiffRepresentation,
-              let resizedBitmap = NSBitmapImageRep(data: resizedTIFF),
-              let cgImage = resizedBitmap.cgImage else {
-            return nil
-        }
-
-        return cgImage
-    }
-
-    /// Convert a Duration to seconds as Double, including both the seconds
-    /// and attoseconds components (not just the sub-second attoseconds part).
     private static func durationToSeconds(_ duration: Duration) -> Double {
         Double(duration.components.seconds) + Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
     }


### PR DESCRIPTION
Benchmarks now measure what users actually do:

- **Render**: `LucideIcon(.house, size: 24)` vs `Image(nsImage: ...)` — SwiftUI View/Image creation
- **Lookup**: `LucideIconName(rawValue:)` vs `NSImage.image(lucideId:)` — type-safe enum vs bundle lookup
- **Memory**: `[LucideIcon]` vs `[NSImage]` — holding Views vs Images

Previously: raw CGContext rasterization, TIFF→BitmapRep→CGImage extraction, raw Shape arrays.