### PR TITLE
docs: mark filled icon style as experimental with Lucide upstream caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ struct ExperimentalView: View {
 #### Filled Icons
 
 > [!WARNING]
-> Filled rendering is **experimental**. Lucide icons are stroke-based, and filling them can result in artifacts on complex or open paths.
+> Filled rendering is **experimental**. Per the [Lucide docs](https://lucide.dev/guide/design/icon-properties), fills are **not officially supported** — Lucide icons are designed as stroke-based line art. Filling can produce visual artifacts on icons with complex or open paths.
 
 ```swift
 // Filled icons using style: parameter

--- a/Sources/LucideSwift/LucideIcon.swift
+++ b/Sources/LucideSwift/LucideIcon.swift
@@ -11,7 +11,12 @@ import SwiftUI
 public enum LucideIconStyle: Sendable {
     /// Stroke-only rendering — the standard Lucide look.
     case stroked
-    /// Filled rendering: closed paths are filled, open paths are stroked.
+    /// **Experimental.** Filled rendering: closed paths are filled, open paths are stroked.
+    ///
+    /// > Important: Lucide icons are designed as stroke-based line art. Fills are
+    /// > [not officially supported](https://lucide.dev/guide/design/icon-properties)
+    /// > by Lucide. Filled rendering may produce visual artifacts on icons with
+    /// > complex or open paths. Use with caution.
     case filled
 }
 

--- a/Sources/LucideSwift/LucideSwift.docc/LucideSwift.md
+++ b/Sources/LucideSwift/LucideSwift.docc/LucideSwift.md
@@ -12,7 +12,7 @@ LucideSwift is a collection of over 1,000 high-quality, open-source icons for Sw
 - **Pure SwiftUI:** Icons are implemented as native `Shape` and `View` components.
 - **Zero Runtime Dependencies:** Icons are pre-generated into Swift code for maximum performance.
 - **Customizable:** Easily adjust size, color, stroke width, and scaling behavior.
-- **Filled Icons:** Switch between stroked and filled rendering with a `style:` parameter.
+- **Filled Icons:** Experimental support for filled rendering via a `style:` parameter. See ``LucideIconStyle/filled`` for caveats.
 
 ## Getting Started
 


### PR DESCRIPTION
Per the [Lucide docs](https://lucide.dev/guide/design/icon-properties), fills are **not officially supported** — Lucide icons are designed as stroke-based line art. Filling can produce visual artifacts on icons with complex or open paths.

## Changes

- **`LucideIconStyle.filled`** — Added `**Experimental.**` label and `Important` callout citing the upstream Lucide position
- **DocC overview** — Updated the "Filled Icons" bullet to note experimental status and cross-reference the enum docs
- **README** — Strengthened the existing warning to explicitly cite the official Lucide docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)