### PR TITLE
chore: align repo with SPI package maintainer recommendations

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,32 +1,20 @@
 version: 1
 metadata:
   authors: "Jiacheng Jiang"
-  keywords:
-    - icons
-    - swiftui
-    - lucide
-    - svg
-    - vector-graphics
-    - shapes
-    - symbol
-    - icon-library
-    - ios
-    - macos
-  summary: "Vector-first, type-safe Swift package for Lucide Icons with native SwiftUI Shape rendering"
-  description: >
-    LucideSwift provides 8,453+ Lucide icons as native SwiftUI Shapes —
-    true vector rendering from SVG path data with zero runtime dependencies.
-    Type-safe API with Xcode autocomplete for all icons, including Lucide Lab
-    experimental icons. Supports iOS 14+, macOS 11+, tvOS 14+, watchOS 7+, visionOS 1+.
 builder:
   configs:
     - platform: ios
       scheme: LucideSwift
+      documentation_targets: ["LucideSwift"]
     - platform: macos-spm
       scheme: LucideSwift
+      documentation_targets: ["LucideSwift"]
     - platform: tvos
       scheme: LucideSwift
+      documentation_targets: ["LucideSwift"]
     - platform: watchos
       scheme: LucideSwift
+      documentation_targets: ["LucideSwift"]
     - platform: visionos
       scheme: LucideSwift
+      documentation_targets: ["LucideSwift"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   <img src="https://img.shields.io/badge/Lucide-1.21.0-orange.svg" alt="Lucide Icons Version">
   <a href="https://github.com/ajaxjiang96/lucide-swift/actions/workflows/sync-and-release.yml"><img src="https://img.shields.io/github/actions/workflow/status/ajaxjiang96/lucide-swift/sync-and-release.yml?branch=main&label=Sync%20%26%20Release" alt="Sync & Release Workflow"></a>
   <br>
-  <a href="https://swiftpackageindex.com/ajaxjiang96/lucide-swift"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fajaxjiang96%2Flucide-swift%2Fbadge%3Ftype%3Dswift-versions" alt="Swift Package Index"></a>
+  <a href="https://swiftpackageindex.com/ajaxjiang96/lucide-swift"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fajaxjiang96%2Flucide-swift%2Fbadge%3Ftype%3Dswift-versions" alt="Swift Versions"></a>
+  <a href="https://swiftpackageindex.com/ajaxjiang96/lucide-swift"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fajaxjiang96%2Flucide-swift%2Fbadge%3Ftype%3Dplatforms" alt="Platforms"></a>
   <br>
   <a href="https://buymeacoffee.com/ajaxjiang"><img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-FFDD00?style=flat&logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee"></a>
 </p>

--- a/Sources/LucideSwift/LucideSwift.docc/LucideSwift.md
+++ b/Sources/LucideSwift/LucideSwift.docc/LucideSwift.md
@@ -4,7 +4,7 @@ Beautiful & consistent icons, made for SwiftUI.
 
 ## Overview
 
-LucideSwift is a collection of over 1,000 high-quality, open-source icons for SwiftUI. It is a Swift implementation of the [Lucide](https://lucide.dev) icon set, providing type-safe, performant, and flexible icon components.
+LucideSwift is a collection of 2,112+ high-quality, open-source icons for SwiftUI (1,738 regular + 374 Lab). It is a Swift implementation of the [Lucide](https://lucide.dev) icon set, providing type-safe, performant, and flexible icon components.
 
 ### Key Features
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ Key differentiator vs other Lucide Swift packages: this package generates pure S
 Shape code from SVG paths rather than bundling image assets (PDFs/PNGs). This means:
 - True vector rendering at any resolution
 - Compile-time verification of icon names
-- Xcode autocomplete for all 1,738+ regular icons + 6,715+ Lab icons
+- Xcode autocomplete for all 1,738+ regular icons + 374 Lab icons
 - ~7× faster enum lookup vs bundle-based image lookup
 - ~2× faster rendering vs PDF rasterization
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,7 @@
 # Lucide Swift
 
 > A vector-first, type-safe Swift package for Lucide Icons with native SwiftUI
-> support. 8,453+ icons rendered as native SwiftUI Shapes from SVG path data —
+> support. 2,112+ icons rendered as native SwiftUI Shapes from SVG path data —
 > zero runtime dependencies.
 
 ## Links
@@ -18,7 +18,7 @@
 Use LucideSwift when you need:
 - A SwiftUI icon library with native vector rendering (no PNG/PDF assets)
 - Type-safe, compile-time-verified icon names with Xcode autocomplete
-- Lucide icons (1,738+ regular + 6,715+ Lab experimental)
+- Lucide icons (1,738+ regular + 374 Lab experimental)
 - Multi-platform SwiftUI support: iOS 14+, macOS 11+, tvOS 14+, watchOS 7+, visionOS 1+
 - A zero-dependency runtime (no third-party packages at runtime)
 
@@ -63,7 +63,7 @@ Label("Settings", lucide: .settings)
 
 - `LucideIcon` — SwiftUI View; init via enum, string name, or LucideShape
 - `LucideIconName` — Enum with 1,738+ cases mapping to Lucide regular icons
-- `LucideLabIconName` — Enum with 6,715+ cases mapping to Lucide Lab experimental icons
+- `LucideLabIconName` — Enum with 374+ cases mapping to Lucide Lab experimental icons
 - `LucideShape` — SwiftUI Shape protocol conformance for every icon
 - `LucideIconStyle` — `.stroked` (default) or `.filled` (experimental)
 - `LucideVersions` — Programmatic access to library version, Lucide version, and Lab version


### PR DESCRIPTION
## Summary

Aligns the repository with [Swift Package Index maintainer recommendations](https://swiftpackageindex.com/ajaxjiang96/lucide-swift/information-for-package-maintainers).

## Changes

### 1. `.spi.yml` — Enable DocC hosting
- Added `documentation_targets: ["LucideSwift"]` to all 5 builder configs (ios, macos-spm, tvos, watchos, visionos) so SPI builds and hosts DocC documentation
- Removed unsupported metadata fields (`keywords`, `summary`, `description`) that are not part of the [SPIManifest spec](https://github.com/SwiftPackageIndex/SPIManifest) — only `authors` is supported in metadata

### 2. README — Add SPI platforms badge
- Added the SPI platform compatibility badge alongside the existing Swift versions badge
- Both badges now use descriptive alt text ("Swift Versions" / "Platforms") instead of the generic "Swift Package Index"

### 3. Fix stale icon counts
- `LucideSwift.docc/LucideSwift.md`: "over 1,000" → "2,112+ (1,738 regular + 374 Lab)"
- `llms.txt`: "8,453+" / "6,715+ Lab" → "2,112+" / "374 Lab"
- `llms-full.txt`: "6,715+ Lab" → "374 Lab"

All counts now match the README.

### 4. Verification
- The `.spi.yml` conforms to the SPIManifest specification
- The platforms badge endpoint returns SVG with "iOS | macOS | visionOS | tvOS | watchOS"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
